### PR TITLE
Shorten items

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,25 +4,25 @@ A reference point for the top tutorials regarding React Native backed by Meteor.
 
 ## Getting Started
 
-- [React Native + Meteor Boilerplate](http://blog.differential.com/react-native-meteor-boilerplate/)
-- [React Native Meteor FAQ](https://medium.com/@spencer_carli/react-native-meteor-faq-919af1db7239#.z5kjham6w)
-- [Pub/Sub versus Methods in React Native Meteor](https://medium.com/@spencer_carli/pub-sub-versus-methods-in-react-native-meteor-eb9213a77633#.mc50h2wgr)
-- [Easily Connect React Native to a Meteor Server](http://blog.differential.com/easily-connect-react-native-to-a-meteor-server/)
+- [Boilerplate](http://blog.differential.com/react-native-meteor-boilerplate/)
+- [FAQ](https://medium.com/@spencer_carli/react-native-meteor-faq-919af1db7239#.z5kjham6w)
+- [Pub/Sub vs Methods](https://medium.com/@spencer_carli/pub-sub-versus-methods-in-react-native-meteor-eb9213a77633#.mc50h2wgr)
+- [Connecting to the server](http://blog.differential.com/easily-connect-react-native-to-a-meteor-server/)
 
 ## Accounts
 
-- [React Native Meteor: Auth with Email, Username, and Password](https://medium.com/@spencer_carli/react-native-meteor-auth-with-email-username-and-password-d2085c732276#.3belsh708)
-- [Password Hashing for Meteor React Native](http://blog.differential.com/password-hashing-for-meteor-react-native/)
+- [Auth with Email, Username, and Password](https://medium.com/@spencer_carli/react-native-meteor-auth-with-email-username-and-password-d2085c732276#.3belsh708)
+- [Password Hashing](http://blog.differential.com/password-hashing-for-meteor-react-native/)
 - [Meteor Authentication from React Native](http://blog.differential.com/meteor-authentication-from-react-native/)
-- [Meteor Google OAuth from React Native](http://blog.differential.com/meteor-google-oauth-from-react-native/)
-- [React Native Meteor: OAuth with Facebook](https://medium.com/@spencer_carli/react-native-meteor-oauth-with-facebook-3d1346d7cdb7#.mo4dh027o)
+- [Google OAuth](http://blog.differential.com/meteor-google-oauth-from-react-native/)
+- [Facebook OAuth](https://medium.com/@spencer_carli/react-native-meteor-oauth-with-facebook-3d1346d7cdb7#.mo4dh027o)
 
 ## Other
 
-- [Sharing Code between Android and iOS in React Native](http://blog.differential.com/sharing-code-between-android-and-ios-in-react-native/)
-- [Intro to Debugging React Native (iOS and Android)](http://blog.differential.com/intro-to-debugging-react-native-ios-and-android/)
-- [React Native + CodePush](http://blog.differential.com/react-native-codepush/)
-- [Exploring Navigators in React Native](https://medium.com/@spencer_carli/exploring-navigators-in-react-native-869b6ab47e0f#.gmf19she4)
+- [Sharing Code between Android and iOS](http://blog.differential.com/sharing-code-between-android-and-ios-in-react-native/)
+- [Intro to Debugging (iOS and Android)](http://blog.differential.com/intro-to-debugging-react-native-ios-and-android/)
+- [CodePush: update without going through the App Store](http://blog.differential.com/react-native-codepush/)
+- [Exploring Navigators](https://medium.com/@spencer_carli/exploring-navigators-in-react-native-869b6ab47e0f#.gmf19she4)
 
 ## Obsolete
 


### PR DESCRIPTION
Thinking it might be easier to read if "Meteor" and "React Native", which are givens for this page, are taken out of items? Also, how is the third Accounts item different from the first? 

Curious why the boilerplate doesn't use the `react-native-meteor` you seem to favor in the FAQ – is it not ready yet?
